### PR TITLE
Add nvim-treesitter filetype-lang parser lookup

### DIFF
--- a/ftplugin/dap-repl.lua
+++ b/ftplugin/dap-repl.lua
@@ -2,7 +2,7 @@ local session = require('dap').session()
 local lang = nil
 
 if session then
-  lang = session.config and session.config.repl_lang or session.filetype
+  lang = session.config and session.config.repl_lang or require("nvim-treesitter.parsers").ft_to_lang(session.filetype) or session.filetype
   if not lang then -- allow user to provide empty string to supress this message
     vim.notify("REPL highlight language not found for current dap session", vim.log.levels.WARN)
   end


### PR DESCRIPTION
Hi @LiadOz 

Thanks for the plugin.

I was working around a difference in the C# filetype (`cs`) and the corresponding TS parser name (`c_sharp`) when I came across this `ft_to_lang` map function provided by `nvim-treesitter.parsers`. I thought it might be useful to add to the plugin, behind the existing `repl_lang` option in priority, as a way to translate between filetypes and TS parser names without requiring explicit setting of `repl_lang`.

I don't have any Neovim plugin development experience so I've just dropped the relevant function in where it seems appropriate to illustrate how it might work - but **it's an untested best guess**.

Hope you find it useful.