### PR TITLE
fix: deprecated checkhealth function

### DIFF
--- a/lua/nvim-dap-repl-highlights/health.lua
+++ b/lua/nvim-dap-repl-highlights/health.lua
@@ -1,20 +1,19 @@
 local M = {}
 
-local rl = require('nvim-dap-repl-highlights')
-local utils = require('nvim-dap-repl-highlights.utils')
+local rl = require("nvim-dap-repl-highlights")
+local utils = require("nvim-dap-repl-highlights.utils")
 
 function M.check()
-  if vim.fn.has('nvim-0.9.0') == 0 then
-    vim.health.report_error("nvim-dap-repl-highlights requires neovim version >= 0.9.0")
-    return
-  end
+	if vim.fn.has("nvim-0.9.0") == 0 then
+		vim.health.report_error("nvim-dap-repl-highlights requires neovim version >= 0.9.0")
+		return
+	end
 
-  if utils.check_treesitter_parser_exists(rl.PARSER_NAME) then
-    vim.health.report_ok("")
-  else
-    vim.health.report_warn(rl.PARSER_NAME .. " parser not installed", "Run TSInstall " .. rl.PARSER_NAME)
-  end
+	if utils.check_treesitter_parser_exists(rl.PARSER_NAME) then
+		vim.health.ok("")
+	else
+		vim.health.report_warn(rl.PARSER_NAME .. " parser not installed", "Run TSInstall " .. rl.PARSER_NAME)
+	end
 end
-
 
 return M

--- a/lua/nvim-dap-repl-highlights/health.lua
+++ b/lua/nvim-dap-repl-highlights/health.lua
@@ -5,14 +5,14 @@ local utils = require("nvim-dap-repl-highlights.utils")
 
 function M.check()
 	if vim.fn.has("nvim-0.9.0") == 0 then
-		vim.health.report_error("nvim-dap-repl-highlights requires neovim version >= 0.9.0")
+		vim.health.error("nvim-dap-repl-highlights requires neovim version >= 0.9.0")
 		return
 	end
 
 	if utils.check_treesitter_parser_exists(rl.PARSER_NAME) then
 		vim.health.ok("")
 	else
-		vim.health.report_warn(rl.PARSER_NAME .. " parser not installed", "Run TSInstall " .. rl.PARSER_NAME)
+		vim.health.warn(rl.PARSER_NAME .. " parser not installed", "Run TSInstall " .. rl.PARSER_NAME)
 	end
 end
 


### PR DESCRIPTION
I just changed the vim.health functions since report_* will be removed in a future version.

Oh, I guess my luacheck automatically changed the single quotes to double quotes in those files, if that's a problem.