### PR TITLE
feat: add nvim-treesitter filetype-lang parser lookup

### DIFF
--- a/ftplugin/dap-repl.lua
+++ b/ftplugin/dap-repl.lua
@@ -2,7 +2,11 @@ local session = require('dap').session()
 local lang = nil
 
 if session then
-  lang = session.config and session.config.repl_lang or session.filetype
+  lang = session.config and session.config.repl_lang
+  if lang == nil then
+    local ok, ts_lang = pcall(require("nvim-treesitter.parsers").ft_to_lang, session.filetype)
+    if ok then lang = ts_lang end
+  end
   if not lang then -- allow user to provide empty string to supress this message
     vim.notify("REPL highlight language not found for current dap session", vim.log.levels.WARN)
   end


### PR DESCRIPTION
Continuing with the work done here: https://github.com/LiadOz/nvim-dap-repl-highlights/pull/5 and addressing your comments.

This makes this plugin work with `typescriptreact` filetypes which uses the `tsx` parser on treesitter.

Tested with typescriptreact files and also with python files. 