### PR TITLE
Fix: deprecated check health functions

### DIFF
--- a/lua/nvim-dap-repl-highlights/health.lua
+++ b/lua/nvim-dap-repl-highlights/health.lua
@@ -2,17 +2,20 @@ local M = {}
 
 local rl = require('nvim-dap-repl-highlights')
 local utils = require('nvim-dap-repl-highlights.utils')
+local ok = vim.health.ok or vim.health.report_ok
+local warn = vim.health.warn or vim.health.report_warn
+local error = vim.health.error or vim.health.report_error
 
 function M.check()
   if vim.fn.has('nvim-0.9.0') == 0 then
-    vim.health.report_error("nvim-dap-repl-highlights requires neovim version >= 0.9.0")
+    error("nvim-dap-repl-highlights requires neovim version >= 0.9.0")
     return
   end
 
   if utils.check_treesitter_parser_exists(rl.PARSER_NAME) then
-    vim.health.report_ok("")
+    ok("")
   else
-    vim.health.report_warn(rl.PARSER_NAME .. " parser not installed", "Run TSInstall " .. rl.PARSER_NAME)
+    warn(rl.PARSER_NAME .. " parser not installed", "Run TSInstall " .. rl.PARSER_NAME)
   end
 end
 


### PR DESCRIPTION
Picking up from [#7](https://github.com/LiadOz/nvim-dap-repl-highlights/pull/7). This should not break compatibility with 0.9.0 as I followed the suggested https://github.com/folke/noice.nvim/pull/438/files and https://github.com/jose-elias-alvarez/null-ls.nvim/pull/1537/files.