### PR TITLE
feat: handle opening REPL before session start

### DIFF
--- a/ftplugin/dap-repl.lua
+++ b/ftplugin/dap-repl.lua
@@ -1,5 +1,6 @@
+local utils = require('nvim-dap-repl-highlights.utils')
 local session = require('dap').session()
-local lang = nil
+local lang = utils.lang
 
 if session then
   lang = session.config and session.config.repl_lang
@@ -12,6 +13,6 @@ if session then
   end
 end
 
-if lang and lang ~= '' then
-  require('nvim-dap-repl-highlights').setup_injections(0, lang)
+if lang ~= '' then
+  utils.lang = require('nvim-dap-repl-highlights').setup_highlights(lang, 0)
 end

--- a/lua/nvim-dap-repl-highlights/init.lua
+++ b/lua/nvim-dap-repl-highlights/init.lua
@@ -25,10 +25,14 @@ function M.setup_highlights(language, bufnr)
   else
     vim.ui.input({prompt = 'Enter language parser name: '}, function(input)
       if input then
+        local ok, ts_lang = pcall(require("nvim-treesitter.parsers").ft_to_lang, input)
+        if ok then input = ts_lang end
         M.setup_injections(bufnr, input)
+        language = input
       end
     end)
   end
+  return language
 end
 
 function M.setup()

--- a/lua/nvim-dap-repl-highlights/utils.lua
+++ b/lua/nvim-dap-repl-highlights/utils.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+M.lang = nil
+
 function M.check_treesitter_parser_exists(language)
   local installed_parsers = require("nvim-treesitter.info").installed_parsers()
   for _, parser in ipairs(installed_parsers) do


### PR DESCRIPTION
Hello!

Thanks for the nice plugin!

This PR addresses the following situation: when the REPL is opened before starting a session (e.g., using `:DapToggleRepl`), it wouldn't get any language injected. I've handled that by using `setup_highlights` instead of `setup_injections` and caching the input.

This approach is hacky, though. I'd much rather use a DAP listener (from `:h dap.listeners`), but I couldn't make it work (I tried using the `initialize` request). The code would get executed, but no language would be injected. I'm not sure why that was happening, but my assumption is that the injection needs to be setup before treesitter starts?

The major drawback of this approach is having to manually set the language, which wouldn't be necessary if using a listener (the DAP config could be read from inside the listener, hence `repl_lang` would be available).