### PR TITLE
Use new nvim-treesitter APIs for setting up the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ require('nvim-dap-repl-highlights').setup()
 ```
 After initially setting up the plugin the dap_repl parser needs to be installed, this can be done manually by running `:TSInstall dap_repl`.
 
+Or automatically through Treesitter configuration:
+
+**Using `ensure_installed` (nvim-treesitter master branch)**
+> ⚠️ **NOTE:** You must call nvim-dap-repl-highlights.setup() before Treesitter, or the dap_repl parser won't be found.
+```lua
+require('nvim-dap-repl-highlights').setup()
+require('nvim-treesitter.configs').setup {
+  highlight = {
+    enable = true,
+  },
+  ensure_installed = { 'dap_repl', ... },
+  ...
+}
+```
+**Using `nvim-treesitter.install` (nvim-treesitter main branch)**
+```lua
+require('nvim-dap-repl-highlights').setup()
+require('nvim-treesitter').install { 'dap_repl' }
+```
+> ⚠️ If this ever stops working or the API changes, check the official Treesitter docs for the latest install method:
+> 👉 https://github.com/nvim-treesitter/nvim-treesitter
+
 ## Usage
 By default, the plugin detects the language to use in the REPL by looking at the **filetype** used to to launch dap. Obviously in order to have syntax highlighting for certain language you will need to have a treesitter parser for that language, alongside the `dap_repl` parser.
 This may not fit all use cases.

--- a/README.md
+++ b/README.md
@@ -13,18 +13,7 @@ Install the plugin and the requirements using your favourite method. Once instal
 ```lua
 require('nvim-dap-repl-highlights').setup()
 ```
-After initially setting up the plugin the dap_repl parser needs to be installed, this can be done manually by running `:TSInstall dap_repl` or by using the `ensure_installed` option of nvim-treesitter.
-**NOTE:** If you use the `ensure_installed` option you must first setup `nvim-dap-repl-highlights` or else the `dap_repl` parser won't be found, for example
-```lua
-require('nvim-dap-repl-highlights').setup()
-require('nvim-treesitter.configs').setup {
-  highlight = {
-    enable = true,
-  },
-  ensure_installed = { 'dap_repl', ... },
-  ...
-}
-```
+After initially setting up the plugin the dap_repl parser needs to be installed, this can be done manually by running `:TSInstall dap_repl`.
 
 ## Usage
 By default, the plugin detects the language to use in the REPL by looking at the **filetype** used to to launch dap. Obviously in order to have syntax highlighting for certain language you will need to have a treesitter parser for that language, alongside the `dap_repl` parser.

--- a/lua/nvim-dap-repl-highlights/utils.lua
+++ b/lua/nvim-dap-repl-highlights/utils.lua
@@ -1,7 +1,16 @@
 local M = {}
 
 function M.check_treesitter_parser_exists(language)
-  local installed_parsers = require("nvim-treesitter.info").installed_parsers()
+  -- nvim-treesitter/info.lua module only exists in master branch
+  local ok, ts_info = pcall(require, "nvim-treesitter.info")
+  local installed_parsers = {}
+
+  if ok then
+    installed_parsers = ts_info.installed_parsers()
+  else
+    installed_parsers = require("nvim-treesitter.config").get_installed("parsers")
+  end
+
   for _, parser in ipairs(installed_parsers) do
     if parser == language then
       return true


### PR DESCRIPTION
This PR adapts the plugin for `nvim-treesitter`'s main branch, which will replace the current master branch soon.

NOTE: the new branch provides `require("nvim-treesitter.config").installed_parsers()` function. It cannot be used here as it considers a parser as installed if the corresponding symlinked query files exist.

Ref: https://github.com/nvim-treesitter/nvim-treesitter/tree/main#adding-parsers