### PR TITLE
Correct `install_info` registration for `nvim-treesitter` main branch

### DIFF
--- a/lua/nvim-dap-repl-highlights/init.lua
+++ b/lua/nvim-dap-repl-highlights/init.lua
@@ -73,13 +73,15 @@ function M.setup()
       },
     }
   else
+    -- `main` branch
     vim.api.nvim_create_autocmd("User", {
       group = vim.api.nvim_create_augroup("nvim_dap_repl_highlights", {}),
       pattern = "TSUpdate",
       callback = function()
-        ts_parsers[M.PARSER_NAME] = {
+        -- This `require` statement must be inlined. Otherwise, the `parsers` table will be reset.
+        require("nvim-treesitter.parsers")[M.PARSER_NAME] = {
           install_info = {
-            path =  parser_path,
+            path = parser_path,
           },
         }
       end,


### PR DESCRIPTION
The [`reload_parsers`](https://github.com/nvim-treesitter/nvim-treesitter/blob/b26b4258294c742c2613a7d98fe53014d1c8fe49/lua/nvim-treesitter/install.lua#L468) function reload the parsers registered in the `nvim-treesitter.parsers` table.

This patch make sure that the custom `dap_repl` parser's `install_info` is properly added back to it. Without this patch, `nvim-treesitter` wouldn't recognise the `dap_repl` parser, and therefore can't install it.